### PR TITLE
Enable access to Test Run ID

### DIFF
--- a/step.yml
+++ b/step.yml
@@ -125,6 +125,9 @@ outputs:
       value_options:
       - succeeded
       - failed
+  - BITRISE_XAMARIN_IOS_UITEST_RUN_ID:
+    opts:
+      title: Run ID for the UI Tests session
   - BITRISE_XAMARIN_TEST_FULL_RESULTS_TEXT:
     opts:
       title: Result of the tests.


### PR DESCRIPTION
In order to do advanced work with the XTC Run ID, we need to get it first, so this PR helps in that direction.
